### PR TITLE
nginx 1.21.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx-quic/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.21.0
+ARG NGINX_VERSION=1.21.1
 
 # https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=5b0c229ba5fe
+ARG NGINX_COMMIT=6674a50cbb6c
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=9aec15e2aa6feea2113119ba06460af70ab3ea62

--- a/readme.md
+++ b/readme.md
@@ -21,11 +21,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.21.0 (quic-5b0c229ba5fe)
+nginx version: nginx/1.21.1 (quic-6674a50cbb6c)
 built by gcc 10.3.1 20210424 (Alpine 10.3.1_git20210424) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
 configure arguments: 
+	--build=quic-6674a50cbb6c 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
https://hg.nginx.org/nginx-quic/rev/a68ac0677f85

```
Changes with nginx 1.21.1                                        06 Jul 2021

    *) Change: now nginx always returns an error for the CONNECT method.

    *) Change: now nginx always returns an error if both "Content-Length"
       and "Transfer-Encoding" header lines are present in the request.

    *) Change: now nginx always returns an error if spaces or control
       characters are used in the request line.

    *) Change: now nginx always returns an error if spaces or control
       characters are used in a header name.

    *) Change: now nginx always returns an error if spaces or control
       characters are used in the "Host" request header line.

    *) Change: optimization of configuration testing when using many
       listening sockets.

    *) Bugfix: nginx did not escape """, "<", ">", "\", "^", "`", "{", "|",
       and "}" characters when proxying with changed URI.

    *) Bugfix: SSL variables might be empty when used in logs; the bug had
       appeared in 1.19.5.

    *) Bugfix: keepalive connections with gRPC backends might not be closed
       after receiving a GOAWAY frame.

    *) Bugfix: reduced memory consumption for long-lived requests when
       proxying with more than 64 buffers.
```