### PR TITLE
Add ngx_http_headers_more_filter_module

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -73,7 +73,7 @@ jobs:
         curl -v --compressed https://localhost:8889 2>&1 | tee /tmp/h2
 
         grep --fixed-strings '< HTTP/2 200' /tmp/h2
-        grep --fixed-strings '< server: nginx' /tmp/h2
+        grep --fixed-strings --invert-match -i '< server: nginx' /tmp/h2 > /dev/null
         grep --fixed-strings '<p>It works!</p>' /tmp/h2
 
 
@@ -81,7 +81,7 @@ jobs:
           curl -v https://localhost:8889 --http3 2>&1 | tee /tmp/h3
 
         grep --fixed-strings '< HTTP/3 200' /tmp/h3
-        grep --fixed-strings '< server: nginx' /tmp/h3
+        grep --fixed-strings --invert-match -i '< server: nginx' /tmp/h3 > /dev/null
         grep --fixed-strings '< alt-svc: h3-27=":8889"; ma=86400, h3-28=":8889"; ma=86400, h3-29=":8889"; ma=86400' /tmp/h3
         grep --fixed-strings '< quic-status: quic' /tmp/h3
         grep --fixed-strings '<p>It works!</p>' /tmp/h3

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -58,7 +58,7 @@ jobs:
         sleep 2; docker ps
         curl -v --compressed localhost:8888 2>&1 | tee /tmp/out
 
-        grep --fixed-strings '< Server: nginx' /tmp/out
+        grep --fixed-strings --invert-match -i '< Server: nginx' /tmp/out > /dev/null
         grep --fixed-strings '< Content-Encoding: br' /tmp/out
         grep --fixed-strings '<p>It works!</p>' /tmp/out
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ ARG NGX_BROTLI_COMMIT=9aec15e2aa6feea2113119ba06460af70ab3ea62
 # https://github.com/google/boringssl
 ARG BORINGSSL_COMMIT=006f20ad7f9a6ce53b44390c0689f3690bf73ad1
 
+# https://github.com/openresty/headers-more-nginx-module#installation
+ARG HEADERS_MORE_VERSION=0.33
+
 # https://hg.nginx.org/nginx-quic/file/quic/README#l72
 ARG CONFIG="\
 		--build=quic-$NGINX_COMMIT-boringssl-$BORINGSSL_COMMIT \
@@ -59,6 +62,7 @@ ARG CONFIG="\
 		--with-http_v2_module \
 		--with-http_v3_module \
 		--add-module=/usr/src/ngx_brotli \
+		--add-module=/usr/src/headers-more-nginx-module-$HEADERS_MORE_VERSION \
 	"
 
 FROM alpine:3.14 AS base
@@ -67,6 +71,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ARG NGINX_VERSION
 ARG NGINX_COMMIT
 ARG NGX_BROTLI_COMMIT
+ARG HEADERS_MORE_VERSION
 ARG CONFIG
 
 RUN \
@@ -126,6 +131,12 @@ RUN \
   && cd build \
   && cmake -GNinja .. \
   && ninja
+
+RUN \
+  echo "Downloading headers-more-nginx-module ..." \
+  && cd /usr/src \
+  && wget https://github.com/openresty/headers-more-nginx-module/archive/refs/tags/v${HEADERS_MORE_VERSION}.tar.gz -O headers-more-nginx-module.tar.gz \
+  && tar -xf headers-more-nginx-module.tar.gz
 
 RUN \
   echo "Building nginx ..." \

--- a/nginx.conf
+++ b/nginx.conf
@@ -33,6 +33,7 @@ http {
     keepalive_timeout  65;
 
     server_tokens off; # disables emitting nginx version in error messages and in the “Server” response header field
+    more_clear_headers 'Server';
 
     gzip  on;
     brotli on;

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ configure arguments:
 	--with-http_v2_module 
 	--with-http_v3_module 
 	--add-module=/usr/src/ngx_brotli 
+	--add-module=/usr/src/headers-more-nginx-module-0.33 
 	--with-cc-opt=-I../boringssl/include 
 	--with-ld-opt='-L../boringssl/build/ssl -L../boringssl/build/crypto'
 ```


### PR DESCRIPTION
* [x] [Clear `Server`](https://github.com/openresty/headers-more-nginx-module#more_clear_headers) and other response headers by default (see #63).

```
adding module in /usr/src/headers-more-nginx-module-0.33
+ ngx_http_headers_more_filter_module was configured
```

https://github.com/openresty/headers-more-nginx-module#installation

----

### Was

```
< HTTP/1.1 200 OK
< Server: nginx
< Date: Mon, 27 Sep 2021 09:26:39 GMT
< Content-Type: text/html
< Last-Modified: Mon, 27 Sep 2021 09:21:10 GMT
< Transfer-Encoding: chunked
< Connection: keep-alive
< ETag: W/"61518d06-20"
< Expires: Tue, 28 Sep 2021 09:26:39 GMT
< Cache-Control: max-age=86400
< Content-Encoding: br
```

### Now

```
< HTTP/1.1 200 OK
< Date: Mon, 27 Sep 2021 09:31:01 GMT
< Content-Type: text/html
< Last-Modified: Mon, 27 Sep 2021 09:25:32 GMT
< Transfer-Encoding: chunked
< Connection: keep-alive
< ETag: W/"61518e0c-20"
< Expires: Tue, 28 Sep 2021 09:31:01 GMT
< Cache-Control: max-age=86400
< Content-Encoding: br
```