### PR TITLE
nginx.conf: set security-related response headers

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -32,9 +32,22 @@ http {
 
     keepalive_timeout  65;
 
+    # security, reveal less information about ourselves
     server_tokens off; # disables emitting nginx version in error messages and in the “Server” response header field
     more_clear_headers 'Server';
+    more_clear_headers 'X-Powered-By';
 
+    # prevent clickjacking attacks
+    more_set_headers 'X-Frame-Options: SAMEORIGIN';
+
+    # help to prevent cross-site scripting exploits
+    more_set_headers 'X-XSS-Protection: 1; mode=block';
+
+    # help to prevent Cross-Site Scripting (XSS) and data injection attacks
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+    more_set_headers "Content-Security-Policy: object-src 'none'; frame-ancestors 'self'; form-action 'self'; block-all-mixed-content; sandbox allow-forms allow-same-origin allow-scripts allow-popups allow-downloads; base-uri 'self';";
+
+    # enable response compression
     gzip  on;
     brotli on;
     brotli_static on;


### PR DESCRIPTION
Inspired by https://github.com/bunkerity/bunkerized-nginx/blob/33e0ffd5b1058fb6e702110f9240dd4703e075a3/misc/variables.env#L106 (resolves #63)

## Headers set by default

```
$ curl 0:8888 -I
HTTP/1.1 200 OK
(...)
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
Content-Security-Policy: object-src 'none'; frame-ancestors 'self'; form-action 'self'; block-all-mixed-content; sandbox allow-forms allow-same-origin allow-scripts allow-popups allow-downloads; base-uri 'self';
(...)
```