### PR TITLE
nginx 1.21.5

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -83,7 +83,7 @@ jobs:
         grep --fixed-strings '< HTTP/3 200' /tmp/h3
         grep --fixed-strings --invert-match -i '< server: nginx' /tmp/h3 > /dev/null
         grep --fixed-strings '< alt-svc: h3-27=":8889"; ma=86400, h3-28=":8889"; ma=86400, h3-29=":8889"; ma=86400' /tmp/h3
-        grep --fixed-strings '< quic-status: quic' /tmp/h3
+        grep --fixed-strings '< quic-status: h3' /tmp/h3
         grep --fixed-strings '<p>It works!</p>' /tmp/h3
 
         docker logs test_nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx-quic/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.21.4
+ARG NGINX_VERSION=1.21.5
 
 # https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=d041b8d6ab0b
+ARG NGINX_COMMIT=de7d36aa9bc7
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=9aec15e2aa6feea2113119ba06460af70ab3ea62

--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.21.4 (quic-d041b8d6ab0b-boringssl-b3ed071ecc4efb77afd0a025ea1078da19578bfd)
+nginx version: nginx/1.21.5 (quic-de7d36aa9bc7-boringssl-b3ed071ecc4efb77afd0a025ea1078da19578bfd)
 built by gcc 10.3.1 20210424 (Alpine 10.3.1_git20210424) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-d041b8d6ab0b-boringssl-b3ed071ecc4efb77afd0a025ea1078da19578bfd 
+	--build=quic-de7d36aa9bc7-boringssl-b3ed071ecc4efb77afd0a025ea1078da19578bfd 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 

--- a/tests/https.conf
+++ b/tests/https.conf
@@ -21,7 +21,7 @@ server {
 
     # Add Alt-Svc header to negotiate HTTP/3.
     add_header alt-svc 'h3-27=":8889"; ma=86400, h3-28=":8889"; ma=86400, h3-29=":8889"; ma=86400';
-    add_header QUIC-Status $quic;     # Sent when QUIC was used
+    add_header QUIC-Status $http3;     # Sent when QUIC was used
 
     location / {
         root   /static;


### PR DESCRIPTION
http://nginx.org/en/CHANGES
```
Changes with nginx 1.21.5                                        28 Dec 2021

    *) Change: now nginx is built with the PCRE2 library by default.

    *) Change: now nginx always uses sendfile(SF_NODISKIO) on FreeBSD.

    *) Feature: support for sendfile(SF_NOCACHE) on FreeBSD.

    *) Feature: the $ssl_curve variable.

    *) Bugfix: connections might hang when using HTTP/2 without SSL with the
       "sendfile" and "aio" directives.
```