### PR TITLE
nginx 1.21.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # https://hg.nginx.org/nginx-quic/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.21.5
+ARG NGINX_VERSION=1.21.6
 
 # https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=de7d36aa9bc7
+ARG NGINX_COMMIT=7c2adf237091
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=9aec15e2aa6feea2113119ba06460af70ab3ea62
 
 # https://github.com/google/boringssl
-ARG BORINGSSL_COMMIT=b3ed071ecc4efb77afd0a025ea1078da19578bfd
+ARG BORINGSSL_COMMIT=123eaaef26abc278f53ae338e9c758eb01c70b08
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 ARG HEADERS_MORE_VERSION=0.33

--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.21.5 (quic-de7d36aa9bc7-boringssl-b3ed071ecc4efb77afd0a025ea1078da19578bfd)
+nginx version: nginx/1.21.6 (quic-7c2adf237091-boringssl-123eaaef26abc278f53ae338e9c758eb01c70b08)
 built by gcc 10.3.1 20210424 (Alpine 10.3.1_git20210424) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-de7d36aa9bc7-boringssl-b3ed071ecc4efb77afd0a025ea1078da19578bfd 
+	--build=quic-7c2adf237091-boringssl-123eaaef26abc278f53ae338e9c758eb01c70b08 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
Bump BoringSSL too

```
Changes with nginx 1.21.6                                        25 Jan 2022

    *) Bugfix: when using EPOLLEXCLUSIVE on Linux client connections were
       unevenly distributed among worker processes.

    *) Bugfix: nginx returned the "Connection: keep-alive" header line in
       responses during graceful shutdown of old worker processes.

    *) Bugfix: in the "ssl_session_ticket_key" when using TLSv1.3.
```