### PR TITLE
nginx 1.23.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG NGINX_VERSION=1.23.2
 
 # https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=98e94553ae51
+ARG NGINX_COMMIT=3be953161026
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx-quic/fie/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.23.1
+ARG NGINX_VERSION=1.23.2
 
 # https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=3550b00d9dc8
+ARG NGINX_COMMIT=98e94553ae51
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc

--- a/readme.md
+++ b/readme.md
@@ -28,12 +28,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.23.1 (quic-3550b00d9dc8-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5)
-built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219)
+nginx version: nginx/1.23.2 (quic-3be953161026-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5)
+built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-3550b00d9dc8-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5 
+	--build=quic-3be953161026-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 
@@ -82,7 +82,7 @@ configure arguments:
 	--add-module=/usr/src/ngx_brotli 
 	--add-module=/usr/src/headers-more-nginx-module-0.34 
 	--add-module=/usr/src/njs/nginx 
-	--add-dynamic-module=/usr/src/ngx_http_geoip2_module
+	--add-dynamic-module=/usr/src/ngx_http_geoip2_module 
 	--with-cc-opt=-I../boringssl/include 
 	--with-ld-opt='-L../boringssl/build/ssl -L../boringssl/build/crypto'
 


### PR DESCRIPTION
```
Changes with nginx 1.23.2                                        19 Oct 2022

    *) Security: processing of a specially crafted mp4 file by the
       ngx_http_mp4_module might cause a worker process crash, worker
       process memory disclosure, or might have potential other impact
       (CVE-2022-41741, CVE-2022-41742).

    *) Feature: the "$proxy_protocol_tlv_..." variables.

    *) Feature: TLS session tickets encryption keys are now automatically
       rotated when using shared memory in the "ssl_session_cache"
       directive.

    *) Change: the logging level of the "bad record type" SSL errors has
       been lowered from "crit" to "info".
       Thanks to Murilo Andrade.

    *) Change: now when using shared memory in the "ssl_session_cache"
       directive the "could not allocate new session" errors are logged at
       the "warn" level instead of "alert" and not more often than once per
       second.

    *) Bugfix: nginx/Windows could not be built with OpenSSL 3.0.x.

    *) Bugfix: in logging of the PROXY protocol errors.
       Thanks to Sergey Brester.

    *) Workaround: shared memory from the "ssl_session_cache" directive was
       spent on sessions using TLS session tickets when using TLSv1.3 with
       OpenSSL.

    *) Workaround: timeout specified with the "ssl_session_timeout"
       directive did not work when using TLSv1.3 with OpenSSL or BoringSSL.
```