### PR TITLE
Bump to nginx 1.23.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx-quic/fie/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.23.2
+ARG NGINX_VERSION=1.23.3
 
 # https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=3be953161026
+ARG NGINX_COMMIT=91ad1abfb285
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc

--- a/readme.md
+++ b/readme.md
@@ -28,12 +28,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.23.2 (quic-3be953161026-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5)
+nginx version: nginx/1.23.3 (quic-91ad1abfb285-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5)
 built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-3be953161026-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5 
+	--build=quic-91ad1abfb285-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.23.3                                        13 Dec 2022

    *) Bugfix: an error might occur when reading PROXY protocol version 2
       header with large number of TLVs.

    *) Bugfix: a segmentation fault might occur in a worker process if SSI
       was used to process subrequests created by other modules.
       Thanks to Ciel Zhao.

    *) Workaround: when a hostname used in the "listen" directive resolves
       to multiple addresses, nginx now ignores duplicates within these
       addresses.

    *) Bugfix: nginx might hog CPU during unbuffered proxying if SSL
       connections to backends were used.
```