### PR TITLE
nginx 1.23.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx-quic/fie/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.23.3
+ARG NGINX_VERSION=1.23.4
 
 # https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=91ad1abfb285
+ARG NGINX_COMMIT=0af598651e33
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc

--- a/readme.md
+++ b/readme.md
@@ -28,12 +28,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.23.3 (quic-91ad1abfb285-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5)
+nginx version: nginx/1.23.4 (quic-0af598651e33-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5)
 built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-91ad1abfb285-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5 
+	--build=quic-0af598651e33-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.23.4                                        28 Mar 2023

    *) Change: now TLSv1.3 protocol is enabled by default.

    *) Change: now nginx issues a warning if protocol parameters of a
       listening socket are redefined.

    *) Change: now nginx closes connections with lingering if pipelining was
       used by the client.

    *) Feature: byte ranges support in the ngx_http_gzip_static_module.

    *) Bugfix: port ranges in the "listen" directive did not work; the bug
       had appeared in 1.23.3.
       Thanks to Valentin Bartenev.

    *) Bugfix: incorrect location might be chosen to process a request if a
       prefix location longer than 255 characters was used in the
       configuration.

    *) Bugfix: non-ASCII characters in file names on Windows were not
       supported by the ngx_http_autoindex_module, the ngx_http_dav_module,
       and the "include" directive.

    *) Change: the logging level of the "data length too long", "length too
       short", "bad legacy version", "no shared signature algorithms", "bad
       digest length", "missing sigalgs extension", "encrypted length too
       long", "bad length", "bad key update", "mixed handshake and non
       handshake data", "ccs received early", "data between ccs and
       finished", "packet length too long", "too many warn alerts", "record
       too small", and "got a fin before a ccs" SSL errors has been lowered
       from "crit" to "info".

    *) Bugfix: a socket leak might occur when using HTTP/2 and the
       "error_page" directive to redirect errors with code 400.

    *) Bugfix: messages about logging to syslog errors did not contain
       information that the errors happened while logging to syslog.
       Thanks to Safar Safarly.

    *) Workaround: "gzip filter failed to use preallocated memory" alerts
       appeared in logs when using zlib-ng.

    *) Bugfix: in the mail proxy server.
```