### PR TITLE
nginx to 1.25.1, other updates, and update docs and configs.

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -104,13 +104,13 @@ jobs:
 
         grep --fixed-strings '< HTTP/3 200' /tmp/h3
         grep --fixed-strings --invert-match -i '< server: nginx' /tmp/h3 > /dev/null
-        grep --fixed-strings '< alt-svc: h3-27=":8889"; ma=86400, h3-28=":8889"; ma=86400, h3-29=":8889"; ma=86400' /tmp/h3
+        grep --fixed-strings '< alt-svc: h3=":8889"; ma=86400' /tmp/h3
         grep --fixed-strings '< quic-status: h3' /tmp/h3
         grep --fixed-strings '<p>It works!</p>' /tmp/h3
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q | grep "Using njs v0.7.7"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q | grep "Using njs v0.8.0"
 
     - name: Show logs
       if: always()

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q | grep "Using njs v0.8.0"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q | grep "Using njs v0.7.12"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc
 ARG BORINGSSL_COMMIT=e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83
 
 # http://hg.nginx.org/njs
-ARG NJS_COMMIT=c2bc1525be25
+ARG NJS_COMMIT=a1faa64d4972
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-# https://hg.nginx.org/nginx-quic/fie/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.23.4
+# https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
+ARG NGINX_VERSION=1.25.1
 
-# https://hg.nginx.org/nginx-quic/shortlog/quic
-ARG NGINX_COMMIT=0af598651e33
+# https://hg.nginx.org/nginx
+ARG NGINX_COMMIT=5b8854a2f79c
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc
 
 # https://github.com/google/boringssl
-ARG BORINGSSL_COMMIT=8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5
+ARG BORINGSSL_COMMIT=e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83
 
 # http://hg.nginx.org/njs
-ARG NJS_COMMIT=b33aae5e8dc6
+ARG NJS_COMMIT=c2bc1525be25
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632
@@ -20,7 +20,7 @@ ARG HEADERS_MORE_VERSION=0.34
 # https://github.com/leev/ngx_http_geoip2_module/releases
 ARG GEOIP2_VERSION=3.4
 
-# https://hg.nginx.org/nginx-quic/file/quic/README#l72
+# https://nginx.org/en/docs/http/ngx_http_v3_module.html
 ARG CONFIG="\
 		--build=quic-$NGINX_COMMIT-boringssl-$BORINGSSL_COMMIT \
 		--prefix=/etc/nginx \
@@ -74,7 +74,7 @@ ARG CONFIG="\
 		--add-dynamic-module=/usr/src/ngx_http_geoip2_module \
 	"
 
-FROM alpine:3.16 AS base
+FROM alpine:3.17 AS base
 
 ARG NGINX_VERSION
 ARG NGINX_COMMIT
@@ -117,8 +117,8 @@ RUN \
 WORKDIR /usr/src/
 
 RUN \
-	echo "Cloning nginx $NGINX_VERSION (rev $NGINX_COMMIT from 'quic' branch) ..." \
-	&& hg clone -b quic --rev $NGINX_COMMIT https://hg.nginx.org/nginx-quic /usr/src/nginx-$NGINX_VERSION
+	echo "Cloning nginx $NGINX_VERSION (rev $NGINX_COMMIT from 'default' branch) ..." \
+	&& hg clone -b default --rev $NGINX_COMMIT https://hg.nginx.org/nginx /usr/src/nginx-$NGINX_VERSION
 
 RUN \
 	echo "Cloning brotli $NGX_BROTLI_COMMIT ..." \
@@ -199,7 +199,7 @@ RUN \
 			| xargs -r apk info --installed \
 			| sort -u > /tmp/runDeps.txt
 
-FROM alpine:3.16
+FROM alpine:3.17
 ARG NGINX_VERSION
 ARG NGINX_COMMIT
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,11 +19,11 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    log_format  quic  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+                      '"$http_user_agent" "$http_x_forwarded_for" "$http3"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /var/log/nginx/access.log  quic;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ configure arguments:
 	--with-ld-opt='-L../boringssl/build/ssl -L../boringssl/build/crypto'
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.8.0
+0.7.12
 ```
 
 ## SSL Grade A+ handling

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,7 @@
 ## What is this?
 [![Docker Image CI](https://github.com/macbre/docker-nginx-http3/actions/workflows/dockerimage.yml/badge.svg)](https://github.com/macbre/docker-nginx-http3/actions/workflows/dockerimage.yml)
 
-Stable and up-to-date [nginx](https://nginx.org/en/CHANGES) with [QUIC + **HTTP/3 experimental support**](https://hg.nginx.org/nginx-quic/shortlog/quic), [Google's `brotli` compression](https://github.com/google/ngx_brotli), [`njs` module](https://nginx.org/en/docs/njs/) and [Grade A+ SSL config](https://ssl-config.mozilla.org/)
-
-nginx binary is built from [`quic` experimental branch](https://hg.nginx.org/nginx-quic/shortlog/quic). It's **not production-ready** yet!
+Stable and up-to-date [nginx](https://nginx.org/en/CHANGES) with [QUIC + **HTTP/3 experimental support**](https://nginx.org/en/docs/http/ngx_http_v3_module.html), [Google's `brotli` compression](https://github.com/google/ngx_brotli), [`njs` module](https://nginx.org/en/docs/njs/) and [Grade A+ SSL config](https://ssl-config.mozilla.org/)
 
 ## How to use this image
 As this project is based on the official [nginx image](https://hub.docker.com/_/nginx/) look for instructions there. In addition to the standard configuration directives, you'll be able to use the brotli module specific ones, see [here for official documentation](https://github.com/google/ngx_brotli#configuration-directives)
@@ -28,12 +26,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.23.4 (quic-0af598651e33-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5)
-built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219) 
+nginx version: nginx/1.25.1 (quic-5b8854a2f79c-boringssl-e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83)
+built by gcc 12.2.1 20220924 (Alpine 12.2.1_git20220924-r4) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-0af598651e33-boringssl-8ce0e1c14e48109773f1e94e5f8b020aa1e24dc5 
+	--build=quic-5b8854a2f79c-boringssl-e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 
@@ -87,7 +85,7 @@ configure arguments:
 	--with-ld-opt='-L../boringssl/build/ssl -L../boringssl/build/crypto'
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.7.7
+0.8.0
 ```
 
 ## SSL Grade A+ handling
@@ -114,10 +112,11 @@ Please refer to `tests/https.conf` config file for an example config used by the
 ```
 server {
     # http/3
-    listen 443 http3 reuseport;
+    listen 443 quic reuseport;
 
     # http/2 and http/1.1
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
 
     server_name localhost;  # customize to match your domain
 
@@ -125,14 +124,14 @@ server {
     ssl_certificate     /etc/nginx/ssl/localhost.crt;
     ssl_certificate_key /etc/nginx/ssl/localhost.key;
 
-    # Enable all TLS versions (TLSv1.3 is required for QUIC).
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    # TLSv1.3 is required for QUIC.
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     # 0-RTT QUIC connection resumption
     ssl_early_data on;
 
     # Add Alt-Svc header to negotiate HTTP/3.
-    add_header alt-svc 'h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400';
+    add_header alt-svc 'h3=":443"; ma=86400';
 
     # Sent when QUIC was used
     add_header QUIC-Status $http3;

--- a/tests/https.conf
+++ b/tests/https.conf
@@ -1,11 +1,11 @@
 # https://www.nginx.com/blog/introducing-technology-preview-nginx-support-for-quic-http-3/
 server {
     # quic and http/3
-    listen 443 http3 reuseport;
+    listen 443 quic reuseport;
 
     # http/2 and http/1.1
-    listen 443 ssl http2;
-
+    listen 443 ssl;
+    http2 on;
     server_name localhost;
 
     # openssl-generated pair for local development
@@ -13,14 +13,14 @@ server {
     ssl_certificate     /etc/nginx/ssl/localhost.crt;
     ssl_certificate_key /etc/nginx/ssl/localhost.key;
 
-    # Enable all TLS versions (TLSv1.3 is required for QUIC).
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    # TLSv1.3 is required for QUIC.
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     # 0-RTT QUIC connection resumption
     ssl_early_data on;
 
     # Add Alt-Svc header to negotiate HTTP/3.
-    add_header alt-svc 'h3-27=":8889"; ma=86400, h3-28=":8889"; ma=86400, h3-29=":8889"; ma=86400';
+    add_header alt-svc 'h3=":8889"; ma=86400';
     add_header QUIC-Status $http3;     # Sent when QUIC was used
 
     location / {


### PR DESCRIPTION
nginx to 1.25.1 and using nginx mainline as opposed to the quic branch
alpine to 3.17
BoringSSL and NJS to the most recent commit
http2 directive used
update docs and configs

#110 