### PR TITLE
apply kn007 ocsp stapling patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN \
 		gd-dev \
 		geoip-dev \
 		perl-dev \
+		patch \
 	&& apk add --no-cache --virtual .brotli-build-deps \
 		autoconf \
 		libtool \
@@ -155,6 +156,14 @@ RUN \
 RUN \
   echo "Downloading ngx_http_geoip2_module ..." \
   && git clone --depth 1 --branch ${GEOIP2_VERSION} https://github.com/leev/ngx_http_geoip2_module /usr/src/ngx_http_geoip2_module
+
+RUN \
+  echo "Downloading Enable_BoringSSL_OCSP patch ..." \
+  && set -eux \
+  && cd /usr/src \
+  && wget -q https://raw.githubusercontent.com/kn007/patch/cd03b77647c9bf7179acac0125151a0fbb4ac7c8/Enable_BoringSSL_OCSP.patch \
+  && cd /usr/src/nginx-$NGINX_VERSION \
+  && patch -p01 < /usr/src/Enable_BoringSSL_OCSP.patch
 
 RUN \
   echo "Cloning and configuring njs ..." \

--- a/tests/https.conf
+++ b/tests/https.conf
@@ -12,7 +12,8 @@ server {
     # https://letsencrypt.org/docs/certificates-for-localhost/
     ssl_certificate     /etc/nginx/ssl/localhost.crt;
     ssl_certificate_key /etc/nginx/ssl/localhost.key;
-
+    ssl_stapling_file /path/to/ocsp.resp;
+    
     # TLSv1.3 is required for QUIC.
     ssl_protocols TLSv1.2 TLSv1.3;
 

--- a/tests/oscp.cron.sh
+++ b/tests/oscp.cron.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+#https://kn007.net/topics/let-nginx-support-ocsp-stapling-when-using-boringssl/
+openssl ocsp -no_nonce \
+             -CAfile /path/to/root.crt \
+             -VAfile /path/to/root.crt \
+             -issuer /path/to/issuer.crt \
+             -cert /path/to/server.crt \
+             -respout /path/to/ocsp.resp \
+             -url "$(openssl x509 -in /path/to/bundle.crt -text | grep "OCSP - URI:" | cut -d: -f2,3)" \
+             > /tmp/ocsp.reply 2>&1
+
+at $(date -d "$(cat /tmp/ocsp.reply | grep 'Next Update: ' | awk -F': ' '{print $2}') + 1 minutes" +"%H:%M %Y-%m-%d") < ~/ocsp.cron.sh
+
+service nginx reload
+
+exit


### PR DESCRIPTION
Ran the dockerfile with the KN007 Enable_BoringSSL_OCSP.patch without error. However i didn't make a test on real https domain..
The KN007 patch is It adds OCSP stapling support for BoringSSL to Nginx using the ssl_stapling_file parameter. However the ssl_stapling_file (/path/to/ocsp.resp)  needs to be renewed from the issuer site every fixed duration and the response will be saved to (/path/to/ocsp.resp)  which is what the cron job does.  You may see the details given on KN007's blog  https://kn007.net/topics/let-nginx-support-ocsp-stapling-when-using-boringssl/. Thanks 