### PR TITLE
nginx 1.25.2 + njs 0.8.1

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q | grep "Using njs v0.7.12"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.1"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.25.1
+ARG NGINX_VERSION=1.25.2
 
 # https://hg.nginx.org/nginx
-ARG NGINX_COMMIT=5b8854a2f79c
+ARG NGINX_COMMIT=44536076405c
 
 # https://github.com/google/ngx_brotli
-ARG NGX_BROTLI_COMMIT=6e975bcb015f62e1f303054897783355e2a877dc
+ARG NGX_BROTLI_COMMIT=63ca02abdcf79c9e788d2eedcc388d2335902e52
 
 # https://github.com/google/boringssl
 ARG BORINGSSL_COMMIT=e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83
 
-# http://hg.nginx.org/njs
-ARG NJS_COMMIT=a1faa64d4972
+# http://hg.nginx.org/njs / v0.8.1
+ARG NJS_COMMIT=a387eed79b90
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.25.1 (quic-5b8854a2f79c-boringssl-e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83)
+nginx version: nginx/1.25.2 (quic-44536076405c-boringssl-e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83)
 built by gcc 12.2.1 20220924 (Alpine 12.2.1_git20220924-r4) 
 built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-5b8854a2f79c-boringssl-e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83 
+	--build=quic-44536076405c-boringssl-e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 
@@ -85,7 +85,7 @@ configure arguments:
 	--with-ld-opt='-L../boringssl/build/ssl -L../boringssl/build/crypto'
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.7.12
+0.8.1
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
```
Changes with nginx 1.25.2                                        15 Aug 2023

    *) Feature: path MTU discovery when using HTTP/3.

    *) Feature: TLS_AES_128_CCM_SHA256 cipher suite support when using
       HTTP/3.

    *) Change: now nginx uses appname "nginx" when loading OpenSSL
       configuration.

    *) Change: now nginx does not try to load OpenSSL configuration if the
       --with-openssl option was used to built OpenSSL and the OPENSSL_CONF
       environment variable is not set.

    *) Bugfix: in the $body_bytes_sent variable when using HTTP/3.

    *) Bugfix: in HTTP/3.
```

```
$ echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q -
Using njs v0.8.1
```

And a few more updated dependencies:

* the latest Brotli changes
* [njs v0.8.1](http://nginx.org/en/docs/njs/changes.html)