### PR TITLE
Fix for "nginx.pid failed (13: Permission denied)" error

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,7 @@ include /etc/nginx/main.d/*.conf;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
+pid        /var/run/nginx/nginx.pid;
 
 events {
     worker_connections  1024;


### PR DESCRIPTION
I assumed this is some kind of permission error, caused by deleting and recreating the file, thus losing the owner set by chown in the Dockerfile. This fix circumvents this, by placing the files in a non-root subdirectory and adjusting the necessary configurations.