### PR TITLE
Update Dockerfile: v1.25.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG NGINX_COMMIT=25a2efd97a3e
 ARG NGX_BROTLI_COMMIT=63ca02abdcf79c9e788d2eedcc388d2335902e52
 
 # https://github.com/google/boringssl
-ARG BORINGSSL_COMMIT=e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83
+#ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
 # http://hg.nginx.org/njs / v0.8.1
 ARG NJS_COMMIT=a387eed79b90
@@ -26,7 +26,7 @@ ARG NGINX_GROUP_GID=101
 
 # https://nginx.org/en/docs/http/ngx_http_v3_module.html
 ARG CONFIG="\
-		--build=quic-$NGINX_COMMIT-boringssl-$BORINGSSL_COMMIT \
+		--build=quic-$NGINX_COMMIT \
 		--prefix=/etc/nginx \
 		--sbin-path=/usr/sbin/nginx \
 		--modules-path=/usr/lib/nginx/modules \
@@ -78,7 +78,7 @@ ARG CONFIG="\
 		--add-dynamic-module=/usr/src/ngx_http_geoip2_module \
 	"
 
-FROM alpine:3.17 AS base
+FROM alpine:3.19 AS base
 
 ARG NGINX_VERSION
 ARG NGINX_COMMIT
@@ -137,20 +137,20 @@ RUN \
 	&& git submodule update --init --depth 1
 
 # hadolint ignore=SC2086
-RUN \
-  echo "Cloning boringssl ..." \
-  && cd /usr/src \
-  && git clone https://github.com/google/boringssl \
-  && cd boringssl \
-  && git checkout $BORINGSSL_COMMIT
+#RUN \
+#  echo "Cloning boringssl ..." \
+#  && cd /usr/src \
+#  && git clone https://github.com/google/boringssl \
+#  && cd boringssl \
+#  && git checkout $BORINGSSL_COMMIT
 
-RUN \
-  echo "Building boringssl ..." \
-  && cd /usr/src/boringssl \
-  && mkdir build \
-  && cd build \
-  && cmake -GNinja .. \
-  && ninja
+#RUN \
+#  echo "Building boringssl ..." \
+#  && cd /usr/src/boringssl \
+#  && mkdir build \
+#  && cd build \
+#  && cmake -GNinja .. \
+#  && ninja
 
 RUN \
   echo "Downloading headers-more-nginx-module ..." \
@@ -177,9 +177,6 @@ RUN \
   && mkdir -p /var/run/nginx/ \
 	&& cd /usr/src/nginx-$NGINX_VERSION \
 	&& ./auto/configure $CONFIG \
-      --with-cc-opt="-I../boringssl/include"   \
-      --with-ld-opt="-L../boringssl/build/ssl  \
-                     -L../boringssl/build/crypto" \
 	&& make -j"$(getconf _NPROCESSORS_ONLN)"
 
 RUN \
@@ -206,7 +203,7 @@ RUN \
 			| xargs -r apk info --installed \
 			| sort -u > /tmp/runDeps.txt
 
-FROM alpine:3.17
+FROM alpine:3.19
 ARG NGINX_VERSION
 ARG NGINX_COMMIT
 ARG NGINX_USER_UID

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.25.2
+ARG NGINX_VERSION=1.25.3
 
 # https://hg.nginx.org/nginx
-ARG NGINX_COMMIT=44536076405c
+ARG NGINX_COMMIT=25a2efd97a3e
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=63ca02abdcf79c9e788d2eedcc388d2335902e52

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.25.2 (quic-44536076405c-boringssl-e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83)
-built by gcc 12.2.1 20220924 (Alpine 12.2.1_git20220924-r4) 
-built with OpenSSL 1.1.1 (compatible; BoringSSL) (running with BoringSSL)
+nginx version: nginx/1.25.3 (quic-25a2efd97a3e)
+built by gcc 13.2.1 20231014 (Alpine 13.2.1_git20231014)
+built with OpenSSL 3.1.4 24 Oct 2023
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-44536076405c-boringssl-e1b8685770d0e82e5a4a3c5d24ad1602e05f2e83 
+	--build=quic-25a2efd97a3e
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 
@@ -81,8 +81,6 @@ configure arguments:
 	--add-module=/usr/src/headers-more-nginx-module-0.34 
 	--add-module=/usr/src/njs/nginx 
 	--add-dynamic-module=/usr/src/ngx_http_geoip2_module 
-	--with-cc-opt=-I../boringssl/include 
-	--with-ld-opt='-L../boringssl/build/ssl -L../boringssl/build/crypto'
 
 $ docker run -it macbre/nginx-http3 njs -v
 0.8.1


### PR DESCRIPTION
```
Changes with nginx 1.25.3                                        24 Oct 2023

    *) Change: improved detection of misbehaving clients when using HTTP/2.

    *) Feature: startup speedup when using a large number of locations.
       Thanks to Yusuke Nojima.

    *) Bugfix: a segmentation fault might occur in a worker process when
       using HTTP/2 without SSL; the bug had appeared in 1.25.1.

    *) Bugfix: the "Status" backend response header line with an empty
       reason phrase was handled incorrectly.

    *) Bugfix: memory leak during reconfiguration when using the PCRE2
       library.
       Thanks to ZhenZhong Wu.

    *) Bugfixes and improvements in HTTP/3.
```