### PR TITLE
nginx 1.25.4 + njs 0.8.3 + headers-more-nginx-module 0.37

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.1"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.3"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.25.3
+ARG NGINX_VERSION=1.25.4
 
 # https://hg.nginx.org/nginx
-ARG NGINX_COMMIT=25a2efd97a3e
+ARG NGINX_COMMIT=89bff782528a
 
 # https://github.com/google/ngx_brotli
-ARG NGX_BROTLI_COMMIT=63ca02abdcf79c9e788d2eedcc388d2335902e52
+ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# http://hg.nginx.org/njs / v0.8.1
-ARG NJS_COMMIT=a387eed79b90
+# http://hg.nginx.org/njs / v0.8.3
+ARG NJS_COMMIT=3aba7ee62080
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632
-ARG HEADERS_MORE_VERSION=0.34
+ARG HEADERS_MORE_VERSION=0.37
 
 # https://github.com/leev/ngx_http_geoip2_module/releases
 ARG GEOIP2_VERSION=3.4

--- a/readme.md
+++ b/readme.md
@@ -26,20 +26,20 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.25.3 (quic-25a2efd97a3e)
-built by gcc 13.2.1 20231014 (Alpine 13.2.1_git20231014)
+nginx version: nginx/1.25.4 (quic-89bff782528a)
+built by gcc 13.2.1 20231014 (Alpine 13.2.1_git20231014) 
 built with OpenSSL 3.1.4 24 Oct 2023
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-25a2efd97a3e
+	--build=quic-89bff782528a 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 
 	--conf-path=/etc/nginx/nginx.conf 
 	--error-log-path=/var/log/nginx/error.log 
 	--http-log-path=/var/log/nginx/access.log 
-	--pid-path=/var/run/nginx.pid 
-	--lock-path=/var/run/nginx.lock 
+	--pid-path=/var/run/nginx/nginx.pid 
+	--lock-path=/var/run/nginx/nginx.lock 
 	--http-client-body-temp-path=/var/cache/nginx/client_temp 
 	--http-proxy-temp-path=/var/cache/nginx/proxy_temp 
 	--http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp 
@@ -78,12 +78,12 @@ configure arguments:
 	--with-http_v2_module 
 	--with-http_v3_module 
 	--add-module=/usr/src/ngx_brotli 
-	--add-module=/usr/src/headers-more-nginx-module-0.34 
+	--add-module=/usr/src/headers-more-nginx-module-0.37 
 	--add-module=/usr/src/njs/nginx 
-	--add-dynamic-module=/usr/src/ngx_http_geoip2_module 
+	--add-dynamic-module=/usr/src/ngx_http_geoip2_module
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.8.1
+0.8.3
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
```

Changes with nginx 1.25.4                                        14 Feb 2024

    *) Security: when using HTTP/3 a segmentation fault might occur in a
       worker process while processing a specially crafted QUIC session
       (CVE-2024-24989, CVE-2024-24990).

    *) Bugfix: connections with pending AIO operations might be closed
       prematurely during graceful shutdown of old worker processes.

    *) Bugfix: socket leak alerts no longer logged when fast shutdown was
       requested after graceful shutdown of old worker processes.

    *) Bugfix: a socket descriptor error, a socket leak, or a segmentation
       fault in a worker process (for SSL proxying) might occur if AIO was
       used in a subrequest.

    *) Bugfix: a segmentation fault might occur in a worker process if SSL
       proxying was used along with the "image_filter" directive and errors
       with code 415 were redirected with the "error_page" directive.

    *) Bugfixes and improvements in HTTP/3.
```