### PR TITLE
nginx v1.25.5 and njs v0.8.4

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.3"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.4"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.25.4
+ARG NGINX_VERSION=1.25.5
 
 # https://hg.nginx.org/nginx
-ARG NGINX_COMMIT=89bff782528a
+ARG NGINX_COMMIT=49dce50fad40
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# http://hg.nginx.org/njs / v0.8.3
-ARG NJS_COMMIT=3aba7ee62080
+# http://hg.nginx.org/njs / v0.8.4
+ARG NJS_COMMIT=7133f0400019
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.25.4 (quic-89bff782528a)
+nginx version: nginx/1.25.5 (quic-49dce50fad40)
 built by gcc 13.2.1 20231014 (Alpine 13.2.1_git20231014) 
 built with OpenSSL 3.1.4 24 Oct 2023
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-89bff782528a 
+	--build=quic-49dce50fad40 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 
@@ -83,7 +83,7 @@ configure arguments:
 	--add-dynamic-module=/usr/src/ngx_http_geoip2_module
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.8.3
+0.8.4
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
### [nginx](https://nginx.org/en/CHANGES)

```
Changes with nginx 1.25.5                                        16 Apr 2024

    *) Feature: virtual servers in the stream module.

    *) Feature: the ngx_stream_pass_module.

    *) Feature: the "deferred", "accept_filter", and "setfib" parameters of
       the "listen" directive in the stream module.

    *) Feature: cache line size detection for some architectures.
       Thanks to Piotr Sikora.

    *) Feature: support for Homebrew on Apple Silicon.
       Thanks to Piotr Sikora.

    *) Bugfix: Windows cross-compilation bugfixes and improvements.
       Thanks to Piotr Sikora.

    *) Bugfix: unexpected connection closure while using 0-RTT in QUIC.
       Thanks to Vladimir Khomutov.
```

### [njs](https://nginx.org/en/docs/njs/changes.html)
Release Date: 16 April 2024

nginx modules:

Feature: the Server header for outgoing header can be set.

Improvement: validating URI and args arguments in [r.subrequest()](https://nginx.org/en/docs/njs/reference.html#r_subrequest).

Improvement: checking for duplicate [js_set](https://nginx.org/en/docs/http/ngx_http_js_module.html#js_set) variables.

Bugfix: fixed [clear()](https://nginx.org/en/docs/njs/reference.html#dict_clear) method of a shared dictionary without a timeout introduced in [0.8.3](https://nginx.org/en/docs/njs/changes.html#njs0.8.3).

Bugfix: fixed [r.send()](https://nginx.org/en/docs/njs/reference.html#r_send) method of a shared dictionary without a timeout with Buffer argument.

Core:

Feature: added QuickJS engine support in CLI.

Bugfix: fixed [atob()](https://nginx.org/en/docs/njs/reference.html#atob) with non-padded base64 strings.
