### PR TITLE
nginx 1.27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.25.5
+ARG NGINX_VERSION=1.27.0
 
-# https://hg.nginx.org/nginx
-ARG NGINX_COMMIT=49dce50fad40
+# https://hg.nginx.org/nginx-quic/
+ARG NGINX_COMMIT=ff0312de0112
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
@@ -124,7 +124,7 @@ WORKDIR /usr/src/
 
 RUN \
 	echo "Cloning nginx $NGINX_VERSION (rev $NGINX_COMMIT from 'default' branch) ..." \
-	&& hg clone -b default --rev $NGINX_COMMIT https://hg.nginx.org/nginx /usr/src/nginx-$NGINX_VERSION
+	&& hg clone -b default --rev $NGINX_COMMIT https://hg.nginx.org/nginx-quic /usr/src/nginx-$NGINX_VERSION
 
 RUN \
 	echo "Cloning brotli $NGX_BROTLI_COMMIT ..." \

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.25.5 (quic-49dce50fad40)
+nginx version: nginx/1.27.0 (quic-ff0312de0112)
 built by gcc 13.2.1 20231014 (Alpine 13.2.1_git20231014) 
-built with OpenSSL 3.1.4 24 Oct 2023
+built with OpenSSL 3.1.5 30 Jan 2024 (running with OpenSSL 3.1.4 24 Oct 2023)
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-49dce50fad40 
+	--build=quic-ff0312de0112 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.27.0                                        29 May 2024

    *) Security: when using HTTP/3, processing of a specially crafted QUIC
       session might cause a worker process crash, worker process memory
       disclosure on systems with MTU larger than 4096 bytes, or might have
       potential other impact (CVE-2024-32760, CVE-2024-31079,
       CVE-2024-35200, CVE-2024-34161).
       Thanks to Nils Bars of CISPA.

    *) Feature: variables support in the "proxy_limit_rate",
       "fastcgi_limit_rate", "scgi_limit_rate", and "uwsgi_limit_rate"
       directives.

    *) Bugfix: reduced memory consumption for long-lived requests if "gzip",
       "gunzip", "ssi", "sub_filter", or "grpc_pass" directives are used.

    *) Bugfix: nginx could not be built by gcc 14 if the --with-atomic
       option was used.
       Thanks to Edgar Bonet.

    *) Bugfixes in HTTP/3.
```