### PR TITLE
Bump to nginx v1.27.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.27.0
+ARG NGINX_VERSION=1.27.1
 
 # https://hg.nginx.org/nginx-quic/
-ARG NGINX_COMMIT=ff0312de0112
+ARG NGINX_COMMIT=8796dfbe7177
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.27.0 (quic-ff0312de0112)
+nginx version: nginx/1.27.1 (quic-8796dfbe7177)
 built by gcc 13.2.1 20231014 (Alpine 13.2.1_git20231014) 
-built with OpenSSL 3.1.6 4 Jun 2024 (running with OpenSSL 3.1.5 30 Jan 2024)
+built with OpenSSL 3.1.6 4 Jun 2024
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-ff0312de0112 
+	--build=quic-8796dfbe7177
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.27.1                                        14 Aug 2024

    *) Security: processing of a specially crafted mp4 file by the
       ngx_http_mp4_module might cause a worker process crash
       (CVE-2024-7347).
       Thanks to Nils Bars.

    *) Change: now the stream module handler is not mandatory.

    *) Bugfix: new HTTP/2 connections might ignore graceful shutdown of old
       worker processes.
       Thanks to Kasei Wang.

    *) Bugfixes in HTTP/3.
```