### PR TITLE
njs v0.8.5

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.4"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.5"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# http://hg.nginx.org/njs / v0.8.4
-ARG NJS_COMMIT=7133f0400019
+# http://hg.nginx.org/njs / v0.8.5
+ARG NJS_COMMIT=a419f9189f55
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 * [`headers-more-nginx-module`](https://github.com/openresty/headers-more-nginx-module#readme) - sets and clears HTTP request and response headers
 * [`ngx_brotli`](https://github.com/google/ngx_brotli#configuration-directives) - adds [brotli response compression](https://datatracker.ietf.org/doc/html/rfc7932)
 * [`ngx_http_geoip2_module`](https://github.com/leev/ngx_http_geoip2_module#download-maxmind-geolite2-database-optional) - creates variables with values from the maxmind geoip2 databases based on the client IP
-* [`njs` module](https://nginx.org/en/docs/njs/) - a subset of the JavaScript language that allows extending nginx functionality
+* [`njs` module](https://nginx.org/en/docs/njs/) - a subset of the JavaScript language that allows extending nginx functionality ([GitHub repository](https://github.com/nginx/njs))
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
@@ -84,7 +84,7 @@ configure arguments:
 	--add-dynamic-module=/usr/src/ngx_http_geoip2_module
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.8.4
+0.8.5
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
## Changes with njs 0.8.5

> Release Date: 25 June 2024

nginx modules:

    Change: [r.variables.var](http://nginx.org/en/docs/njs/reference.html#r_variables), [r.requestText](http://nginx.org/en/docs/njs/reference.html#r_request_text), [r.responseText](http://nginx.org/en/docs/njs/reference.html#r_response_text), [s.variables.var](http://nginx.org/en/docs/njs/reference.html#s_variables), and the data argument of the [s.on()](http://nginx.org/en/docs/njs/reference.html#njs_on) callback with upload or download event types will now convert bytes invalid in UTF-8 encoding into the replacement character. When working with binary data, use [r.rawVariables.var](http://nginx.org/en/docs/njs/reference.html#r_raw_variables), [r.requestBuffer](http://nginx.org/en/docs/njs/reference.html#r_request_buffer), [r.responseBuffer](http://nginx.org/en/docs/njs/reference.html#r_response_buffer), [s.rawVariables.var](http://nginx.org/en/docs/njs/reference.html#s_raw_variables), and the upstream or downstream event type for [s.on()](http://nginx.org/en/docs/njs/reference.html#njs_on) instead.

    Feature: added timeout argument for [add()](http://nginx.org/en/docs/njs/reference.html#dict_add), [set()](http://nginx.org/en/docs/njs/reference.html#dict_set), and [incr()](http://nginx.org/en/docs/njs/reference.html#dict_incr) methods of a shared dictionary.

    Bugfix: fixed checking for duplicate [js_set](http://nginx.org/en/docs/http/ngx_http_js_module.html#js_set) variables.

    Bugfix: fixed request Host header when the port is non-standard.

    Bugfix: fixed handling of a zero-length request body in [ngx.fetch()](http://nginx.org/en/docs/njs/reference.html#ngx_fetch) and [r.subrequest()](http://nginx.org/en/docs/njs/reference.html#r_subrequest).

    Bugfix: fixed heap-buffer-overflow in Headers.get().

    Bugfix: fixed [r.subrequest()](http://nginx.org/en/docs/njs/reference.html#r_subrequest) error handling.

Core:

    Feature: added zlib module for QuickJS engine.

    Bugfix: fixed [zlib.inflate()](http://nginx.org/en/docs/njs/reference.html#zlib_inflatesync).

    Bugfix: fixed String.prototype.replaceAll() with a zero-length argument.

    Bugfix: fixed retval handling after an exception in Array.prototype.toSpliced(), Array.prototype.toReversed(), Array.prototype.toSorted().

    Bugfix: fixed RegExp.prototype[@@replace]() with replacements containing $', $` and strings with Unicode characters.

    Bugfix: fixed a one-byte overread in decodeURI() and decodeURIComponent().

    Bugfix: fixed tracking of argument scope.

    Bugfix: fixed integer overflow in Date.parse().