### PR TITLE
Bump to nginx 1.27.2

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.5"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.6"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.27.1
+ARG NGINX_VERSION=1.27.2
 
-# https://hg.nginx.org/nginx-quic/
-ARG NGINX_COMMIT=8796dfbe7177
+# https://hg.nginx.org/nginx/
+ARG NGINX_COMMIT=331eae3dccf8
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# https://github.com/nginx/njs/releases/tag/0.8.5
-ARG NJS_COMMIT=9d4bf6c60aa60a828609f64d1b5c50f71bb7ef62
+# https://github.com/nginx/njs/releases/tag/0.8.6
+ARG NJS_COMMIT=c5a29a7af8894ee1ec44ebda71ef0ea1f2a31af6
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632
@@ -26,7 +26,7 @@ ARG NGINX_GROUP_GID=101
 
 # https://nginx.org/en/docs/http/ngx_http_v3_module.html
 ARG CONFIG="\
-		--build=quic-$NGINX_COMMIT \
+		--build=$NGINX_COMMIT \
 		--prefix=/etc/nginx \
 		--sbin-path=/usr/sbin/nginx \
 		--modules-path=/usr/lib/nginx/modules \
@@ -125,7 +125,7 @@ WORKDIR /usr/src/
 
 RUN \
 	echo "Cloning nginx $NGINX_VERSION (rev $NGINX_COMMIT from 'default' branch) ..." \
-	&& hg clone -b default --rev $NGINX_COMMIT https://hg.nginx.org/nginx-quic /usr/src/nginx-$NGINX_VERSION
+	&& hg clone -b default --rev $NGINX_COMMIT https://hg.nginx.org/nginx/ /usr/src/nginx-$NGINX_VERSION
 
 RUN \
 	echo "Cloning brotli $NGX_BROTLI_COMMIT ..." \

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.27.1 (quic-8796dfbe7177)
+nginx version: nginx/1.27.2 (331eae3dccf8)
 built by gcc 13.2.1 20240309 (Alpine 13.2.1_git20240309) 
-built with OpenSSL 3.3.1 4 Jun 2024
+built with OpenSSL 3.3.2 3 Sep 2024
 TLS SNI support enabled
 configure arguments: 
-	--build=quic-8796dfbe7177
+	--build=331eae3dccf8
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 
@@ -84,7 +84,7 @@ configure arguments:
 	--add-dynamic-module=/usr/src/ngx_http_geoip2_module
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.8.5
+0.8.6
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
```
Changes with nginx 1.27.2                                        02 Oct 2024

    *) Feature: SSL certificates, secret keys, and CRLs are now cached on
       start or during reconfiguration.

    *) Feature: client certificate validation with OCSP in the stream
       module.

    *) Feature: OCSP stapling support in the stream module.

    *) Feature: the "proxy_pass_trailers" directive in the
       ngx_http_proxy_module.

    *) Feature: the "ssl_client_certificate" directive now supports
       certificates with auxiliary information.

    *) Change: now the "ssl_client_certificate" directive is not required
       for client SSL certificates verification.
```

* Use the main code repository, nginx-quic is gone
* Update the njs to the latest version