### PR TITLE
 Use njs 0.8.7

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.6"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.7"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# https://github.com/nginx/njs/releases/tag/0.8.6
-ARG NJS_COMMIT=c5a29a7af8894ee1ec44ebda71ef0ea1f2a31af6
+# https://github.com/nginx/njs/releases/tag/0.8.7
+ARG NJS_COMMIT=ba6b9e157ef472dbcac17e32c55f3227daa3103c
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ configure arguments:
 	--with-ld-opt='-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto'
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.8.6
+0.8.7
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
```
Changes with njs 0.8.7                                       22 Oct 2024
    nginx modules:
    *) Bugfix: eliminated unnecessary VM creation.
       Previously, njs consumed memory proportionally to the number of
       nginx locations. The issue was introduced in 9b674412 (0.8.6).
    *) Improvement: added strict syntax validation for js_body_filter.
    *) Improvement: improved error messages for module loading
       failures.
    Core:
    *) Feature: implemented fs.readlink() and friends.
    *) Improvement: implemented lazy stack symbolization.
    *) Bugfix: fixed heap-buffer-overflow in Buffer.prototype.indexOf().
       The issue was introduced in 5d15a8d6 (0.8.6).
    *) Bugfix: fixed Buffer.prototype.lastIndexOf() when `from` is
       provided.
```