### PR TITLE
quickjs: add the engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,8 @@ RUN \
 		openssl-dev \
 		pcre-dev \
 		readline-dev \
-		zlib-dev
+		zlib-dev \
+	&& git config --global init.defaultBranch master
 
 WORKDIR /usr/src/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -175,7 +175,8 @@ RUN \
   && cd /usr/src \
   && git clone https://github.com/bellard/quickjs quickjs \
   && cd quickjs \
-  && make libquickjs.a
+  && make libquickjs.a \
+  && echo "quickjs $(cat VERSION)"
 
 RUN \
   echo "Cloning and configuring njs ..." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -188,7 +188,6 @@ RUN \
   && git checkout -q FETCH_HEAD \
   && ./configure  --cc-opt='-I /usr/src/quickjs' --ld-opt="-L /usr/src/quickjs" \
   && make njs \
-  && ls -lh /usr/src/njs/* \
   && mv /usr/src/njs/build/njs /usr/sbin/njs \
   && echo "njs v$(njs -v)"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,13 @@ RUN \
 	&& apk add --no-cache --virtual .geoip2-build-deps \
 		libmaxminddb-dev \
 	&& apk add --no-cache --virtual .njs-build-deps \
-		readline-dev
+		libedit-dev \
+		libxml2-dev \
+		libxslt-dev \
+		openssl-dev \
+		pcre-dev \
+		readline-dev \
+		zlib-dev
 
 WORKDIR /usr/src/
 
@@ -165,21 +171,28 @@ RUN \
   && git clone --depth 1 --branch ${GEOIP2_VERSION} https://github.com/leev/ngx_http_geoip2_module /usr/src/ngx_http_geoip2_module
 
 RUN \
+  echo "Cloning and configuring quickjs ..." \
+  && cd /usr/src \
+  && git clone https://github.com/bellard/quickjs quickjs \
+  && cd quickjs \
+  && make libquickjs.a
+
+RUN \
   echo "Cloning and configuring njs ..." \
-  && mkdir /usr/src/njs \
-  && cd /usr/src/njs \
+  && mkdir /usr/src/njs && cd /usr/src/njs \
   && git init \
   && git remote add origin https://github.com/nginx/njs.git \
   && git fetch --depth 1 origin ${NJS_COMMIT} \
   && git checkout -q FETCH_HEAD \
-  && ./configure \
+  && ./configure  --cc-opt='-I /usr/src/quickjs' --ld-opt="-L /usr/src/quickjs" \
   && make njs \
+  && ls -lh /usr/src/njs/* \
   && mv /usr/src/njs/build/njs /usr/sbin/njs \
   && echo "njs v$(njs -v)"
 
 # https://github.com/macbre/docker-nginx-http3/issues/152
-ARG CC_OPT='-g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects'
-ARG LD_OPT='-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto'
+ARG CC_OPT='-g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -I /usr/src/quickjs'
+ARG LD_OPT='-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto -L /usr/src/quickjs'
 RUN \
   echo "Building nginx ..." \
   && mkdir -p /var/run/nginx/ \

--- a/readme.md
+++ b/readme.md
@@ -82,8 +82,8 @@ configure arguments:
 	--add-module=/usr/src/headers-more-nginx-module-0.37 
 	--add-module=/usr/src/njs/nginx 
 	--add-dynamic-module=/usr/src/ngx_http_geoip2_module
-	--with-cc-opt='-g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects' 
-	--with-ld-opt='-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto'
+	--with-cc-opt='-g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -I /usr/src/quickjs' 
+	--with-ld-opt='-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto -L /usr/src/quickjs'
 
 $ docker run -it macbre/nginx-http3 njs -v
 0.8.7


### PR DESCRIPTION
```
QuickJS version 2024-01-13
(...)
14 4.403 NJS configuration summary:
14 4.403
14 4.403  + using CC: "cc"
14 4.403  + using CFLAGS: " -pipe -fPIC -fvisibility=hidden -O -W -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wmissing-prototypes -Werror -g -fexcess-precision=standard -I /usr/src/quickjs "
14 4.403
14 4.403  + using PCRE library: -lpcre
14 4.403  + using readline library: -ledit
14 4.403  + using QuickJS library: -lquickjs -lm -ldl -lpthread
14 4.403  + using OpenSSL library: -lcrypto
14 4.403  + using libxml2 library: -lxml2
14 4.403  + using zlib library: -L/lib -lz
14 4.403
14 4.403  njs build dir: build
14 4.403  njs CLI: build/njs
(...)
15 8.768 adding module in /usr/src/njs/nginx
15 8.769 checking for QuickJS library -lquickjs.lto ... not found
15 8.829 checking for QuickJS library -lquickjs ... found
15 8.984 checking for QuickJS JS_NewTypedArray() ... found
15 9.072  enabled QuickJS engine
15 9.072  enabled webcrypto module
15 9.073  enabled xml module
15 9.074  enabled zlib module
15 9.075  + ngx_js_module was configured
```