### PR TITLE
nginx 1.27.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.27.2
+ARG NGINX_VERSION=1.27.3
 
 # https://hg.nginx.org/nginx/
-ARG NGINX_COMMIT=331eae3dccf8
+ARG NGINX_COMMIT=c7f94e6c96ee
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53


### PR DESCRIPTION
https://github.com/nginx/nginx/releases/tag/release-1.27.3

```
Changes with nginx 1.27.3                                        26 Nov 2024

    *) Feature: the "server" directive in the "upstream" block supports the
       "resolve" parameter.

    *) Feature: the "resolver" and "resolver_timeout" directives in the
       "upstream" block.

    *) Feature: SmarterMail specific mode support for IMAP LOGIN with
       untagged CAPABILITY response in the mail proxy module.

    *) Change: now TLSv1 and TLSv1.1 protocols are disabled by default.

    *) Change: an IPv6 address in square brackets and no port can be
       specified in the "proxy_bind", "fastcgi_bind", "grpc_bind",
       "memcached_bind", "scgi_bind", and "uwsgi_bind" directives, and as
       client address in ngx_http_realip_module.

    *) Bugfix: in the ngx_http_mp4_module.
       Thanks to Nils Bars.

    *) Bugfix: the "so_keepalive" parameter of the "listen" directive might
       be handled incorrectly on DragonFly BSD.

    *) Bugfix: in the "proxy_store" directive.
```