### PR TITLE
nginx 1.27.4

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -102,7 +102,7 @@ jobs:
         docker run --rm --network host ghcr.io/macbre/curl-http3 \
           curl -v --insecure https://localhost:8889 --http3 --max-time 5 2>&1 | tee /tmp/h3
 
-        grep --fixed-strings '< HTTP/3 200' /tmp/h3
+        grep --fixed-strings 'HTTP/3 200' /tmp/h3
         grep --fixed-strings --invert-match -i '< server: nginx' /tmp/h3 > /dev/null
         grep --fixed-strings '< alt-svc: h3=":8889"; ma=86400' /tmp/h3
         grep --fixed-strings '< quic-status: h3' /tmp/h3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.27.3
+ARG NGINX_VERSION=1.27.4
 
 # https://hg.nginx.org/nginx/
-ARG NGINX_COMMIT=c7f94e6c96ee
+ARG NGINX_COMMIT=cfa2aef9a28c
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53

--- a/readme.md
+++ b/readme.md
@@ -27,12 +27,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.27.3 (c7f94e6c96ee)
+nginx version: nginx/1.27.4 (cfa2aef9a28c)
 built by gcc 13.2.1 20240309 (Alpine 13.2.1_git20240309) 
 built with OpenSSL 3.3.2 3 Sep 2024
 TLS SNI support enabled
 configure arguments: 
-	--build=c7f94e6c96ee
+	--build=cfa2aef9a28c
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.27.4                                        05 Feb 2025

    *) Security: insufficient check in virtual servers handling with TLSv1.3
       SNI allowed to reuse SSL sessions in a different virtual server, to
       bypass client SSL certificates verification (CVE-2025-23419).

    *) Feature: the "ssl_object_cache_inheritable", "ssl_certificate_cache",
       "proxy_ssl_certificate_cache", "grpc_ssl_certificate_cache", and
       "uwsgi_ssl_certificate_cache" directives.

    *) Feature: the "keepalive_min_timeout" directive.

    *) Workaround: "gzip filter failed to use preallocated memory" alerts
       appeared in logs when using zlib-ng.

    *) Bugfix: nginx could not build libatomic library using the library
       sources if the --with-libatomic=DIR option was used.

    *) Bugfix: QUIC connection might not be established when using 0-RTT;
       the bug had appeared in 1.27.1.

    *) Bugfix: nginx now ignores QUIC version negotiation packets from
       clients.

    *) Bugfix: nginx could not be built on Solaris 10 and earlier with the
       ngx_http_v3_module.

    *) Bugfixes in HTTP/3.
```