### PR TITLE
nginx 1.27.5 + njs 0.8.10

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.7"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.10"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.27.4
+ARG NGINX_VERSION=1.27.5
 
 # https://hg.nginx.org/nginx/
-ARG NGINX_COMMIT=cfa2aef9a28c
+ARG NGINX_COMMIT=a91a4caf0523
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# https://github.com/nginx/njs/releases/tag/0.8.7
-ARG NJS_COMMIT=ba6b9e157ef472dbcac17e32c55f3227daa3103c
+# https://github.com/nginx/njs/releases/tag/0.8.10
+ARG NJS_COMMIT=9d3e71ca656b920e3e63b0e647aca8e91669d29a
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/readme.md
+++ b/readme.md
@@ -27,12 +27,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.27.4 (cfa2aef9a28c)
+nginx version: nginx/1.27.5 (a91a4caf0523)
 built by gcc 13.2.1 20240309 (Alpine 13.2.1_git20240309) 
-built with OpenSSL 3.3.2 3 Sep 2024
+built with OpenSSL 3.3.3 11 Feb 2025
 TLS SNI support enabled
 configure arguments: 
-	--build=cfa2aef9a28c
+	--build=a91a4caf0523 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 
@@ -77,18 +77,19 @@ configure arguments:
 	--with-compat 
 	--with-file-aio 
 	--with-http_v2_module 
-	--with-http_v3_module
-	--with-openssl-opt=enable-ktls
+	--with-http_v3_module 
+	--with-openssl-opt=enable-ktls 
 	--add-module=/usr/src/ngx_brotli 
 	--add-module=/usr/src/headers-more-nginx-module-0.37 
 	--add-module=/usr/src/njs/nginx 
-	--add-module=/usr/src/zstd
-	--add-dynamic-module=/usr/src/ngx_http_geoip2_module
-	--with-cc-opt='-g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -I /usr/src/quickjs'
+	--add-module=/usr/src/zstd 
+	--add-dynamic-module=/usr/src/ngx_http_geoip2_module 
+	--with-cc-opt='-g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -I /usr/src/quickjs' 
 	--with-ld-opt='-Wl,-Bsymbolic-functions -flto=auto -ffat-lto-objects -flto=auto -L /usr/src/quickjs'
 
+
 $ docker run -it macbre/nginx-http3 njs -v
-0.8.7
+0.8.10
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
```
Changes with nginx 1.27.5                                        16 Apr 2025

    *) Feature: CUBIC congestion control in QUIC connections.

    *) Change: the maximum size limit for SSL sessions cached in shared
       memory has been raised to 8192.

    *) Bugfix: in the "grpc_ssl_password_file", "proxy_ssl_password_file",
       and "uwsgi_ssl_password_file" directives when loading SSL
       certificates and encrypted keys from variables; the bug had appeared
       in 1.23.1.

    *) Bugfix: in the $ssl_curve and $ssl_curves variables when using
       pluggable curves in OpenSSL.

    *) Bugfix: nginx could not be built with musl libc.
       Thanks to Piotr Sikora.

    *) Performance improvements and bugfixes in HTTP/3.
```