### PR TITLE
headers-more: bump to v0.38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG NJS_COMMIT=9d3e71ca656b920e3e63b0e647aca8e91669d29a
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632
-ARG HEADERS_MORE_VERSION=0.37
+ARG HEADERS_MORE_VERSION=0.38
 
 # https://github.com/leev/ngx_http_geoip2_module/releases
 ARG GEOIP2_VERSION=3.4

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ configure arguments:
 	--with-http_v3_module 
 	--with-openssl-opt=enable-ktls 
 	--add-module=/usr/src/ngx_brotli 
-	--add-module=/usr/src/headers-more-nginx-module-0.37 
+	--add-module=/usr/src/headers-more-nginx-module-0.38 
 	--add-module=/usr/src/njs/nginx 
 	--add-module=/usr/src/zstd 
 	--add-dynamic-module=/usr/src/ngx_http_geoip2_module 


### PR DESCRIPTION
https://github.com/openresty/headers-more-nginx-module/releases/tag/v0.38