### PR TITLE
njs: bump to v0.9.0

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.8.10"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.9.0"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# https://github.com/nginx/njs/releases/tag/0.8.10
-ARG NJS_COMMIT=9d3e71ca656b920e3e63b0e647aca8e91669d29a
+# https://github.com/nginx/njs/releases/tag/0.9.0
+ARG NJS_COMMIT=fcb99b68f86a72c96e21b81b3b78251174dbd3bf
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ configure arguments:
 
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.8.10
+0.9.0
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
https://github.com/nginx/njs/releases/tag/0.9.0

```
Changes with njs 0.9.0                                       06 May 2025

     Core:

     *) Feature: refactored working with built-in strings, symbols
        and small integers.
        Performance improvements (arewefastyet/benchmarks/v8-v7 benchmark):
        Richards: +57% (631 → 989)
        Crypto: +7% (1445 → 1551)
        RayTrace: +37% (562 → 772)
        NavierStokes: +20% (2062 → 2465)
        Overall score: +29% (1014 → 1307)

    *) Bugfix: fixed regexp undefined value of captured group.

    *) Bugfix: fixed GCC 15 build with -Wunterminated-string-initialization.
```