### PR TITLE
Bump njs to v0.9.1

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.9.0"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.9.1"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# https://github.com/nginx/njs/releases/tag/0.9.0
-ARG NJS_COMMIT=fcb99b68f86a72c96e21b81b3b78251174dbd3bf
+# https://github.com/nginx/njs/releases/tag/0.9.1
+ARG NJS_COMMIT=4fd3ff98e413ede57c88456cf84b116a8382061a
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ configure arguments:
 
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.9.0
+0.9.1
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
```
Changes with njs 0.9.1                                       10 Jul 2025

    nginx modules:
    *) Feature: added Fetch API for QuickJS engine.
    *) Feature: added state file for a shared dictionary.
    *) Bugfix: fixed handling of Content-Length header when
       a body is provided for Fetch API.
    *) Bugfix: fixed qjs engine after bellard/quickjs@458c34d2.
    *) Bugfix: fixed NULL pointer dereference when processing
       If-* headers.

    Core:
    *) Feature: added ECDH support for WebCrypto.
    *) Improvement: reduced memory consumption by the object hash.
       The new hash uses 42% less memory per element.
    *) Improvement: reduced memory consumption for concatenation of
       numbers and strings.
    *) Improvement: reduced memory consumption of
       String.prototype.concat() with scalar values.
    *) Bugfix: fixed segfault in njs_property_query().
       The issue was introduced in b28e50b1 (0.9.0).
    *) Bugfix: fixed Function constructor template injection.
    *) Bugfix: fixed GCC compilation with O3 optimization level.
    *) Bugfix: fixed constant is too large for 'long' warning
       on MIPS -mabi=n32.
    *) Bugfix: fixed compilation with GCC 4.1.
    *) Bugfix: fixed %TypedArray%.from() with the buffer is detached
       by the mapper.
    *) Bugfix: fixed %TypedArray%.prototype.slice() with overlapping
       buffers.
    *) Bugfix: fixed handling of detached buffers for typed arrays.
    *) Bugfix: fixed frame saving for async functions with
       closures.
    *) Bugfix: fixed RegExp compilation of patterns with
       escaped '[' characters.
```