### PR TITLE
nginx 1.29.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.29.0
+ARG NGINX_VERSION=1.29.1
 
 # https://hg.nginx.org/nginx/
-ARG NGINX_COMMIT=aff13bf32357
+ARG NGINX_COMMIT=1db7c7ba4bc5
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG NGINX_VERSION=1.29.1
 
 # https://hg.nginx.org/nginx/
-ARG NGINX_COMMIT=1db7c7ba4bc5
+ARG NGINX_COMMIT=68813362708e
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53

--- a/readme.md
+++ b/readme.md
@@ -27,12 +27,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.29.0 (aff13bf32357)
+nginx version: nginx/1.29.1 (1db7c7ba4bc5)
 built by gcc 13.2.1 20240309 (Alpine 13.2.1_git20240309) 
-built with OpenSSL 3.3.3 11 Feb 2025
+built with OpenSSL 3.3.4 1 Jul 2025
 TLS SNI support enabled
 configure arguments: 
-	--build=aff13bf32357
+	--build=68813362708e 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.29.1                                        13 Aug 2025

    *) Security: processing of a specially crafted login/password when using
       the "none" authentication method in the ngx_mail_smtp_module might
       cause worker process memory disclosure to the authentication server
       (CVE-2025-53859).

    *) Change: now TLSv1.3 certificate compression is disabled by default.

    *) Feature: the "ssl_certificate_compression" directive.

    *) Feature: support for 0-RTT in QUIC when using OpenSSL 3.5.1 or newer.

    *) Bugfix: the 103 response might be buffered when using HTTP/2 and the
       "early_hints" directive.

    *) Bugfix: in handling "Host" and ":authority" header lines with equal
       values when using HTTP/2; the bug had appeared in 1.17.9.

    *) Bugfix: in handling "Host" header lines with a port when using
       HTTP/3.

    *) Bugfix: nginx could not be built on NetBSD 10.0.

    *) Bugfix: in the "none" parameter of the "smtp_auth" directive.
```