### PR TITLE
njs: upgrade to 0.9.2

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.9.1"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.9.2"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# https://github.com/nginx/njs/releases/tag/0.9.1
-ARG NJS_COMMIT=4fd3ff98e413ede57c88456cf84b116a8382061a
+# https://github.com/nginx/njs/releases/tag/0.9.2
+ARG NJS_COMMIT=b31f7333c772ba837977363536297b2608f64047
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ configure arguments:
 
 
 $ docker run -it macbre/nginx-http3 njs -v
-0.9.1
+0.9.2
 ```
 
 ## SSL Grade A+ handling


### PR DESCRIPTION
This release adds [HTTP keepalive support](https://nginx.org/en/docs/http/ngx_http_js_module.html#js_fetch_keepalive) to [ngx.fetch() API](https://nginx.org/en/docs/njs/reference.html#ngx_fetch). Additionally, the [njs.on('exit') API](https://nginx.org/en/docs/njs/reference.html#njs_on) was added for [qjs](https://nginx.org/en/docs/njs/engine.html) engine.

## What's Changed

    Change: increasing the default stack size to 160k. by @xeioex in https://github.com/nginx/njs/pull/950
    Fixed building QuickJS support with clang 19. by @xeioex in https://github.com/nginx/njs/pull/958
    Fix long running streams in tcp stream by @xeioex in https://github.com/nginx/njs/pull/954
    Qjs exit hook by @xeioex in https://github.com/nginx/njs/pull/959
    Fetch keepalive support. by @xeioex in https://github.com/nginx/njs/pull/963
    Fixed build with GCC 15 and O3 optimization level. by @xeioex in https://github.com/nginx/njs/pull/965
    Fix no ssl build by @xeioex in https://github.com/nginx/njs/pull/966