### PR TITLE
nginx/1.29.2 + njs/0.9.3

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -110,7 +110,7 @@ jobs:
 
     - name: Test njs command line
       run: |
-        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.9.2"
+        echo "console.log('Using njs v' + njs.version)" | docker run -i --rm macbre/nginx njs -q - | grep "Using njs v0.9.3"
 
     - name: Show logs
       if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53
 # https://github.com/google/boringssl
 #ARG BORINGSSL_COMMIT=fae0964b3d44e94ca2a2d21f86e61dabe683d130
 
-# https://github.com/nginx/njs/releases/tag/0.9.2
-ARG NJS_COMMIT=b31f7333c772ba837977363536297b2608f64047
+# https://github.com/nginx/njs/releases/tag/0.9.3
+ARG NJS_COMMIT=5115c78ea0259fa7ef42b629eda4964fbf63aba5
 
 # https://github.com/openresty/headers-more-nginx-module#installation
 # we want to have https://github.com/openresty/headers-more-nginx-module/commit/e536bc595d8b490dbc9cf5999ec48fca3f488632

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://hg.nginx.org/nginx/file/tip/src/core/nginx.h
-ARG NGINX_VERSION=1.29.1
+ARG NGINX_VERSION=1.29.2
 
 # https://hg.nginx.org/nginx/
-ARG NGINX_COMMIT=68813362708e
+ARG NGINX_COMMIT=d2a04c09eb4d
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53


### PR DESCRIPTION
```
Changes with nginx 1.29.2                                        07 Oct 2025

    *) Feature: now nginx can be built with AWS-LC.
       Thanks Samuel Chiang.

    *) Bugfix: now the "ssl_protocols" directive works in a virtual server
       different from the default server when using OpenSSL 1.1.1 or newer.

    *) Bugfix: SSL handshake always failed when using TLSv1.3 with OpenSSL
       and client certificates and resuming a session with a different SNI
       value; the bug had appeared in 1.27.4.

    *) Bugfix: the "ignoring stale global SSL error" alerts might appear in
       logs when using QUIC and the "ssl_reject_handshake" directive; the
       bug had appeared in 1.29.0.
       Thanks to Vladimir Homutov.

    *) Bugfix: in delta-seconds processing in the "Cache-Control" backend
       response header line.

    *) Bugfix: an XCLIENT command didn't use the xtext encoding.
       Thanks to Igor Morgenstern of Aisle Research.

    *) Bugfix: in SSL certificate caching during reconfiguration.
```