### PR TITLE
nginx 1.29.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://github.com/nginx/nginx/blob/master/src/core/nginx.h
-ARG NGINX_VERSION=1.29.6
+ARG NGINX_VERSION=1.29.7
 
 # https://github.com/nginx/nginx/releases
-ARG NGINX_COMMIT=cb85fbb
+ARG NGINX_COMMIT=5ac6f49
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53

--- a/readme.md
+++ b/readme.md
@@ -27,12 +27,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.29.6 (cb85fbb)
+nginx version: nginx/1.29.7 (5ac6f49)
 built by gcc 13.2.1 20240309 (Alpine 13.2.1_git20240309) 
 built with OpenSSL 3.3.6 27 Jan 2026
 TLS SNI support enabled
 configure arguments: 
-	--build=cb85fbb 
+	--build=5ac6f49 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.29.7                                        24 Mar 2026

    *) Security: a buffer overflow might occur while handling a COPY or MOVE
       request in a location with "alias", allowing an attacker to modify
       the source or destination path outside of the document root
       (CVE-2026-27654).
       Thanks to Calif.io in collaboration with Claude and Anthropic
       Research.

    *) Security: processing of a specially crafted mp4 file by the
       ngx_http_mp4_module on 32-bit platforms might cause a worker process
       crash, or might have potential other impact (CVE-2026-27784).
       Thanks to Prabhav Srinath (sprabhav7).

    *) Security: processing of a specially crafted mp4 file by the
       ngx_http_mp4_module might cause a worker process crash, or might have
       potential other impact (CVE-2026-32647).
       Thanks to Xint Code and Pavel Kohout (Aisle Research).

    *) Security: a segmentation fault might occur in a worker process if the
       CRAM-MD5 or APOP authentication methods were used and authentication
       retry was enabled (CVE-2026-27651).
       Thanks to Arkadi Vainbrand.

    *) Security: an attacker might use PTR DNS records to inject data in
       auth_http requests, as well as in the XCLIENT command in the backend
       SMTP connection (CVE-2026-28753).
       Thanks to Asim Viladi Oglu Manizada, Colin Warren, Xiao Liu (Yunnan
       University), Yuan Tan (UC Riverside), and Bird Liu (Lanzhou
       University).

    *) Security: SSL handshake might succeed despite OCSP rejecting a client
       certificate in the stream module (CVE-2026-28755).
       Thanks to Mufeed VH of Winfunc Research.

    *) Feature: the "multipath" parameter of the "listen" directive.

    *) Feature: the "local" parameter of the "keepalive" directive in the
       "upstream" block.

    *) Change: now the "keepalive" directive in the "upstream" block is
       enabled by default.

    *) Change: now ngx_http_proxy_module supports keepalive by default; the
       default value for "proxy_http_version" is "1.1"; the "Connection"
       proxy header is not sent by default anymore.

    *) Bugfix: an invalid HTTP/2 request might be sent after switching to
       the next upstream if buffered body was used in the
       ngx_http_grpc_module.
```