### PR TITLE
nginx 1.29.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://github.com/nginx/nginx/blob/master/src/core/nginx.h
-ARG NGINX_VERSION=1.29.7
+ARG NGINX_VERSION=1.29.8
 
 # https://github.com/nginx/nginx/releases
-ARG NGINX_COMMIT=5ac6f49
+ARG NGINX_COMMIT=5eaf45f
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53

--- a/readme.md
+++ b/readme.md
@@ -27,12 +27,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.29.7 (5ac6f49)
+nginx version: nginx/1.29.8 (5eaf45f)
 built by gcc 13.2.1 20240309 (Alpine 13.2.1_git20240309) 
-built with OpenSSL 3.3.6 27 Jan 2026
+built with OpenSSL 3.3.7 7 Apr 2026 (running with OpenSSL 3.3.6 27 Jan 2026)
 TLS SNI support enabled
 configure arguments: 
-	--build=5ac6f49 
+	--build=5eaf45f 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.29.8                                        07 Apr 2026

    *) Feature: the "max_headers" directive.
       Thanks to Maxim Dounin.

    *) Feature: OpenSSL 4.0 compatibility.

    *) Feature: now the "include" directive inside the "geo" block supports
       wildcards.

    *) Bugfix: in processing of HTTP 103 (Early Hints) responses from a
       proxied backend.

    *) Bugfix: the $request_port and $is_request_port variables were not
       available in subrequests.
```