### PR TITLE
nginx 1.31.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://github.com/nginx/nginx/blob/master/src/core/nginx.h
-ARG NGINX_VERSION=1.31.1
+ARG NGINX_VERSION=1.31.2
 
 # https://github.com/nginx/nginx/releases
-ARG NGINX_COMMIT=d442052
+ARG NGINX_COMMIT=2fd01ed
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53

--- a/readme.md
+++ b/readme.md
@@ -29,12 +29,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.31.1 (d442052)
+nginx version: nginx/1.31.2 (2fd01ed)
 built by gcc 15.2.0 (Alpine 15.2.0) 
-built with OpenSSL 3.5.6 7 Apr 2026
+built with OpenSSL 3.5.7 9 Jun 2026 (running with OpenSSL 3.5.6 7 Apr 2026)
 TLS SNI support enabled
 configure arguments: 
-	--build=d442052 
+	--build=2fd01ed 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.31.2                                        17 Jun 2026

    *) Security: use-after-free might occur when using HTTP/3 and processing
       a specially crafted QUIC session, allowing an attacker to cause
       worker process memory corruption or segmentation fault in a worker
       process (CVE-2026-42530).
       Thanks to Trung Nguyen of CyStack.

    *) Security: a heap memory buffer overflow might occur in a worker
       process when using a configuration with "ignore_invalid_headers off;"
       and "large_client_header_buffers" with large configured values when
       proxying a specially crafted request to HTTP/2 or gRPC backend,
       allowing an attacker to cause worker process memory corruption or
       segmentation fault in a worker process (CVE-2026-42055).
       Thanks to Mufeed VH of Winfunc Research.

    *) Security: a heap memory buffer overread might occur in a worker
       process while handling a specially sent response with decoding from
       UTF-8 via the "charset_map" directive, allowing an attacker to cause
       a limited disclosure of worker proccess memory or segmentation fault
       in a worker process (CVE-2026-48142).
       Thanks to Han Yan of Xiaomi and p4p3r of CYBERONE.

    *) Change: now the $request_id variable uses SipHash-2-4.

    *) Feature: the $ssl_sigalgs variable.

    *) Bugfix: a variable defined by the "split_clients" directive might be
       empty if all percentages were specified explicitly and summed up to
       100%.

    *) Bugfix: constant time "secure_link" hash comparison.
       Thanks to kodareef5.
```