### PR TITLE
nginx 1.31.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # https://github.com/nginx/nginx/blob/master/src/core/nginx.h
-ARG NGINX_VERSION=1.31.2
+ARG NGINX_VERSION=1.31.3
 
 # https://github.com/nginx/nginx/releases
-ARG NGINX_COMMIT=2fd01ed
+ARG NGINX_COMMIT=073ab5d
 
 # https://github.com/google/ngx_brotli
 ARG NGX_BROTLI_COMMIT=a71f9312c2deb28875acc7bacfdd5695a111aa53

--- a/readme.md
+++ b/readme.md
@@ -29,12 +29,12 @@ docker pull ghcr.io/macbre/nginx-http3:latest
 
 ```
 $ docker run -it macbre/nginx-http3 nginx -V
-nginx version: nginx/1.31.2 (2fd01ed)
+nginx version: nginx/1.31.3 (073ab5d)
 built by gcc 15.2.0 (Alpine 15.2.0) 
-built with OpenSSL 3.5.7 9 Jun 2026 (running with OpenSSL 3.5.6 7 Apr 2026)
+built with OpenSSL 3.5.7 9 Jun 2026
 TLS SNI support enabled
 configure arguments: 
-	--build=2fd01ed 
+	--build=073ab5d 
 	--prefix=/etc/nginx 
 	--sbin-path=/usr/sbin/nginx 
 	--modules-path=/usr/lib/nginx/modules 


### PR DESCRIPTION
```
Changes with nginx 1.31.3                                        15 Jul 2026

    *) Security: heap buffer overflow might occur in a worker process when
       using the map directive with regex matching if the map variable was
       included in a string expression after a capture affected by this map;
       a similar issue might happen when using a non-cacheable variable in a
       string expression (CVE-2026-42533).
       Thanks to Mufeed VH of Winfunc Research and Maxim Dounin.

    *) Security: uninitialized memory access might occur when using unnamed
       regex captures with the "slice" directive or background cache update,
       which could result in worker process memory disclosure or worker
       process termination (CVE-2026-60005).

    *) Security: use-after-free might occur when processing a specially
       crafted proxied backend response with the ngx_http_ssi_filter_module
       (CVE-2026-56434).
       Thanks to P4P3R-HAK.

    *) Change: the size of headers and trailers in HTTP/2 responses in the
       ngx_http_proxy_v2_module and ngx_http_grpc_module is now limited with
       "proxy_buffer_size" and "grpc_buffer_size" directives.

    *) Change: loading of external entities is now disabled in the
       ngx_http_xslt_filter_module.
       Thanks to Maxim Dounin.

    *) Feature: the "xml_external_entities" directive in the
       ngx_http_xslt_filter_module.
       Thanks to Maxim Dounin.

    *) Feature: the "proxy_socket_sndbuf", "proxy_socket_rcvbuf",
       "fastcgi_socket_sndbuf", "fastcgi_socket_rcvbuf",
       "grpc_socket_sndbuf", "grpc_socket_rcvbuf", "scgi_socket_sndbuf",
       "scgi_socket_rcvbuf", "uwsgi_socket_sndbuf", "uwsgi_socket_rcvbuf",
       "tunnel_socket_sndbuf", and "tunnel_socket_rcvbuf" directives.

    *) Feature: cache line size detection for loongarch64.
       Thanks to Miao Wang.

    *) Bugfix: now nginx rejects HTTP/2 requests with out-of-order
       pseudo-headers.

    *) Bugfix: in flow control in the ngx_http_v2_module.

    *) Bugfix: "[error] upstream sent frame for unknown stream" and "[crit]
       cache file ... contains invalid header" messages might appear in logs
       when sending a cached HTTP/2 response in the ngx_http_proxy_v2_module
       if the "proxy_cache_revalidate" directive was used.

    *) Bugfix: nginx might send the "Upgrade" header line in HTTP/2 and
       HTTP/3 responses.

    *) Bugfix: in the ngx_http_perl_module.
       Thanks to Maxim Dounin.

    *) Bugfix: IPv6 fragmentation might not be disabled when using QUIC on
       some operating systems.

    *) Bugfix: in the ngx_http_auth_basic_module on Solaris.

    *) Bugfixes and improvements in the ngx_http_tunnel_module.
```